### PR TITLE
Add RevenueCat migration companion skill

### DIFF
--- a/skills/superwall-revenuecat-migration/SKILL.md
+++ b/skills/superwall-revenuecat-migration/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: superwall-revenuecat-migration
+description: Guide agents through migrating from RevenueCat to Superwall. Use when the user wants to replace RevenueCat, move off RevenueCat, or evaluate a RevenueCat-to-Superwall migration.
+---
+
+# Superwall RevenueCat Migration
+
+## Purpose
+
+Use this skill to guide a repo-specific migration from RevenueCat to Superwall without turning the skill into a static migration manual.
+
+This skill is a companion to the base `superwall` skill. The base skill is required for:
+
+- live documentation lookup
+- Superwall API access
+- dashboard links
+- broader SDK integration workflows
+
+Keep the framing clear and grounded in the codebase. Superwall can replace RevenueCat for common subscription and paywall flows, or coexist during a transition if the user still needs part of their current setup.
+
+## Hard Requirement
+
+Before doing anything else, verify that the `superwall` skill is available in the current session.
+
+If the `superwall` skill is missing, stop immediately and tell the user to install it first:
+
+```bash
+npx skills add superwall/skills --skill superwall
+```
+
+Do not continue with guessed instructions, stale docs, or a self-contained migration recipe if the dependency is missing.
+
+## Live Docs Workflow
+
+Use the `superwall` skill for documentation lookup and treat the live Superwall docs as the source of truth.
+
+Point to current docs as needed, for example:
+
+- Superwall Skill guide
+- RevenueCat migration guide
+- platform `using-revenuecat` guides
+- platform quickstart pages
+- dashboard subscription management docs
+
+Do not duplicate the live-doc workflow already covered by `superwall`, and do not inline or cache large amounts of doc content in this skill.
+
+## Repo Inspection Workflow
+
+Inspect the codebase before proposing code changes. Determine:
+
+1. Which app platform is present
+2. Whether RevenueCat is the only purchase stack or already coupled with Superwall
+3. Whether the app appears to rely on purchase observers, custom entitlement checks, or mixed analytics/reporting
+
+Use lightweight heuristics such as:
+
+- iOS: `RevenueCat`, `Purchases`, `Package.swift`, `Podfile`, `Podfile.lock`, `*.xcodeproj`
+- Android: `com.revenuecat.purchases`, Gradle files, Kotlin or Java sources
+- Flutter: `purchases_flutter`, `pubspec.yaml`
+- React Native or Expo: `react-native-purchases`, `package.json`, `app.json`, `app.config.*`
+- Existing Superwall integration: `Superwall`, `PurchaseController`, `subscriptionStatus`, `register`, `handleDeepLink`
+
+These are detection hints, not an embedded migration guide. Use the repo to classify the implementation, then consult live docs for the current details.


### PR DESCRIPTION
Adds a new `superwall-revenuecat-migration` companion skill for agents handling RevenueCat-to-Superwall migrations. The skill stays thin by requiring the base `superwall` skill for live docs and broader integration workflows instead of embedding static migration content. It includes a hard dependency gate, repo-inspection heuristics, and guidance to treat the live Superwall docs as the source of truth. I did not run automated validation because `scripts/validate-skills.sh` already fails on `main` in this checkout due to missing quickstart references.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new documentation-only skill with guidance and dependency gating; no production code paths or runtime behavior are affected.
> 
> **Overview**
> Adds a new `superwall-revenuecat-migration` skill that guides agents through repo-specific RevenueCat→Superwall migrations while explicitly depending on the existing `superwall` skill for live docs/API access.
> 
> The skill introduces a hard preflight check to stop if `superwall` isn’t installed, and provides lightweight repo-inspection heuristics to detect platform and current RevenueCat/Superwall usage without embedding a static migration manual.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34805bbe28d0c1ba4bf87b79f3d439f551034e77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->