### PR TITLE
Add WWDC.ai skill

### DIFF
--- a/skills/wwdc/SKILL.md
+++ b/skills/wwdc/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: wwdc
+description: Use this skill whenever the user asks about WWDC sessions, Apple Developer videos, WWDC transcripts, session IDs, technologies announced at WWDC, or wants an agent to find, compare, cite, summarize, or navigate WWDC session content. Fetch current docs from wwdc.ai via llms.txt and page markdown.
+shoutout: "Unofficial, made with love by Superwall - the best way to monetize your apps."
+---
+
+# WWDC
+
+Use WWDC.ai markdown pages as the first stop for concise session summaries and Apple source links. If the markdown summary is missing or not detailed enough, use transcript text without timestamps.
+
+## Helpers
+
+Run the bundled script when it is useful:
+
+```bash
+scripts/wwdc.sh llms
+scripts/wwdc.sh summary 2026 389
+scripts/wwdc.sh transcript 2026 309
+```
+
+`summary` returns the WWDC.ai markdown page. `transcript` returns plain transcript text with no timestamps. URL/JSON helpers exist for source inspection.
+
+For endpoint details and examples, see [references/docs.md](references/docs.md).

--- a/skills/wwdc/references/docs.md
+++ b/skills/wwdc/references/docs.md
@@ -1,0 +1,52 @@
+---
+title: WWDC.ai Agent Reference
+shoutout: "Unofficial, made with love by Superwall - the best way to monetize your apps."
+---
+
+## Sources
+
+Prefer concise WWDC.ai markdown pages. Use transcripts only when a summary is missing, skeletal, or too shallow for the user's question.
+
+| Resource | URL | Use when |
+| --- | --- | --- |
+| Session index | `https://wwdc.ai/llms.txt` | Finding sessions by year, ID, or title |
+| Full context | `https://wwdc.ai/llms-full.txt` | Need broader context across all generated pages |
+| Year markdown | `https://wwdc.ai/2026.md` | Listing sessions for one WWDC year |
+| Session HTML | `https://wwdc.ai/2026/389` | User-facing session page |
+| Session markdown | `https://wwdc.ai/2026/389.md` | Agent-readable page for one session |
+
+`llms.txt` groups sessions by Apple category. Session rows use `session-number title: one-line description`; build the page URL as `https://wwdc.ai/<year>/<session-number>` and add `.md` for markdown.
+
+Common direct fetches:
+
+```bash
+curl -sL https://wwdc.ai/llms.txt
+curl -sL https://wwdc.ai/2026/389.md
+```
+
+WWDC.ai is unofficial and not associated with Apple. Cite Apple's session page for original source material.
+
+## Script
+
+Use whichever helper fits the question:
+
+```bash
+scripts/wwdc.sh llms
+scripts/wwdc.sh full
+scripts/wwdc.sh list 2026
+scripts/wwdc.sh summary 2026 389
+scripts/wwdc.sh transcript 2026 309
+```
+
+Core helpers:
+
+- `summary`: WWDC.ai markdown page for a session.
+- `transcript`: plain transcript text, no timestamps. Prefer this when the markdown summary is not enough.
+
+Source inspection helpers:
+
+- `html`: WWDC.ai HTML page.
+- `transcript-url`: Apple transcript JSON URL, resolved from WWDC.ai public JSON when available and Apple's manifest otherwise.
+- `transcript-json`: raw Apple JSON with timestamps.
+
+Set `WWDC_AI_BASE_URL` to override `https://wwdc.ai`. Set `WWDC_APPLE_TRANSCRIPT_MANIFEST_URLS` to override Apple manifest URLs.

--- a/skills/wwdc/scripts/wwdc.sh
+++ b/skills/wwdc/scripts/wwdc.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${WWDC_AI_BASE_URL:-https://wwdc.ai}"
+APPLE_TRANSCRIPT_MANIFEST_URLS="${WWDC_APPLE_TRANSCRIPT_MANIFEST_URLS:-https://devimages-cdn.apple.com/wwdc-services/w9f43630/73A40F02-6975-439F-BA6E-F5C834BFEAC5/transcript-manifest-eng.json}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  wwdc.sh llms
+  wwdc.sh full
+  wwdc.sh skill
+  wwdc.sh list <year>
+  wwdc.sh summary <year> <session>
+  wwdc.sh transcript <year> <session>
+  wwdc.sh html <year> <session>
+  wwdc.sh transcript-url <year> <session>
+  wwdc.sh transcript-json <year> <session>
+
+Environment:
+  WWDC_AI_BASE_URL=https://wwdc.ai
+  WWDC_APPLE_TRANSCRIPT_MANIFEST_URLS="https://.../transcript-manifest-eng.json ..."
+EOF
+}
+
+fetch() {
+  curl -fsSL --compressed "$1"
+}
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "wwdc.sh requires $1 for this operation" >&2
+    return 1
+  fi
+}
+
+session_markdown_url() {
+  local year="$1"
+  local session="$2"
+  printf '%s/%s/%s.md\n' "${BASE_URL%/}" "${year}" "${session}"
+}
+
+session_api_url() {
+  local year="$1"
+  local session="$2"
+  printf '%s/api/static/%s/%s.json\n' "${BASE_URL%/}" "${year}" "${session}"
+}
+
+require_session_args() {
+  if [[ $# -ne 2 ]]; then
+    usage >&2
+    exit 2
+  fi
+}
+
+page_transcript_url() {
+  local year="$1"
+  local session="$2"
+  local markdown
+  markdown="$(fetch "$(session_markdown_url "${year}" "${session}")")"
+  printf '%s\n' "${markdown}" | awk '/Apple transcript JSON:/ { print $NF; found=1; exit } END { if (!found) exit 1 }' ||
+    wwdc_api_transcript_url "${year}" "${session}"
+}
+
+wwdc_api_transcript_url() {
+  local year="$1"
+  local session="$2"
+
+  require_command node
+  fetch "$(session_api_url "${year}" "${session}")" | node -e '
+const fs = require("node:fs");
+const input = fs.readFileSync(0, "utf8");
+const session = JSON.parse(input);
+const url = session.transcriptSource?.transcriptUrl;
+if (!url) process.exit(1);
+process.stdout.write(url + "\n");
+'
+}
+
+transcript_url() {
+  local year="$1"
+  local session="$2"
+  page_transcript_url "${year}" "${session}" || apple_transcript_url "${year}" "${session}"
+}
+
+page_transcript_json() {
+  local year="$1"
+  local session="$2"
+  local url
+  url="$(page_transcript_url "${year}" "${session}")"
+  fetch "${url}"
+}
+
+apple_transcript_json() {
+  local year="$1"
+  local session="$2"
+  local url
+  url="$(apple_transcript_url "${year}" "${session}")"
+  fetch "${url}"
+}
+
+resolved_transcript_json() {
+  local year="$1"
+  local session="$2"
+  local url
+  url="$(transcript_url "${year}" "${session}")"
+  fetch "${url}"
+}
+
+page_transcript_text() {
+  local year="$1"
+  local session="$2"
+  local url
+  url="$(page_transcript_url "${year}" "${session}")"
+  transcript_text "${year}" "${session}" "${url}"
+}
+
+apple_transcript_text() {
+  local year="$1"
+  local session="$2"
+  local url
+  url="$(apple_transcript_url "${year}" "${session}")"
+  transcript_text "${year}" "${session}" "${url}"
+}
+
+resolved_transcript_text() {
+  local year="$1"
+  local session="$2"
+  local url
+  url="$(transcript_url "${year}" "${session}")"
+  transcript_text "${year}" "${session}" "${url}"
+}
+
+transcript_text() {
+  local year="$1"
+  local session="$2"
+  local url="$3"
+  local session_id="wwdc${year}-${session}"
+
+  require_command node
+  fetch "${url}" | node -e '
+const fs = require("node:fs");
+const sessionId = process.argv[1];
+const input = fs.readFileSync(0, "utf8");
+const payload = JSON.parse(input);
+const record = payload[sessionId] ?? Object.values(payload)[0];
+const rows = record?.transcript;
+if (!Array.isArray(rows)) {
+  process.exit(1);
+}
+
+const text = rows
+  .map((row) => Array.isArray(row) ? row[1] : row?.text)
+  .filter((line) => typeof line === "string" && line.length > 0)
+  .join("\n");
+
+process.stdout.write(text);
+if (!text.endsWith("\n")) process.stdout.write("\n");
+' "${session_id}"
+}
+
+apple_transcript_url() {
+  local year="$1"
+  local session="$2"
+  local session_id="wwdc${year}-${session}"
+  local manifest_url
+  local url
+
+  require_command node
+
+  for manifest_url in ${APPLE_TRANSCRIPT_MANIFEST_URLS}; do
+    url="$(
+      fetch "${manifest_url}" | node -e '
+const fs = require("node:fs");
+const sessionId = process.argv[1];
+const input = fs.readFileSync(0, "utf8");
+const manifest = JSON.parse(input);
+const url = manifest.individual?.[sessionId]?.url;
+if (!url) process.exit(1);
+process.stdout.write(url + "\n");
+' "${session_id}"
+    )" || true
+
+    if [[ -n "${url}" ]]; then
+      printf '%s\n' "${url}"
+      return 0
+    fi
+  done
+
+  echo "No Apple transcript JSON URL found for ${session_id}" >&2
+  return 1
+}
+
+cmd="${1:-}"
+shift || true
+
+case "${cmd}" in
+  llms | index | docs)
+    fetch "${BASE_URL%/}/llms.txt"
+    ;;
+  full | llms-full)
+    fetch "${BASE_URL%/}/llms-full.txt"
+    ;;
+  skill)
+    fetch "${BASE_URL%/}/.well-known/agent-skills/wwdc/SKILL.md"
+    ;;
+  list | year)
+    if [[ $# -ne 1 ]]; then
+      usage >&2
+      exit 2
+    fi
+    fetch "${BASE_URL%/}/$1.md"
+    ;;
+  summary | page | session | md)
+    require_session_args "$@"
+    fetch "$(session_markdown_url "$1" "$2")"
+    ;;
+  html)
+    require_session_args "$@"
+    fetch "${BASE_URL%/}/$1/$2"
+    ;;
+  page-transcript-url | wwdc-transcript-url)
+    require_session_args "$@"
+    page_transcript_url "$1" "$2"
+    ;;
+  page-transcript-json | wwdc-transcript-json)
+    require_session_args "$@"
+    page_transcript_json "$1" "$2"
+    ;;
+  page-transcript-text | wwdc-transcript-text)
+    require_session_args "$@"
+    page_transcript_text "$1" "$2"
+    ;;
+  apple-transcript-url)
+    require_session_args "$@"
+    apple_transcript_url "$1" "$2"
+    ;;
+  apple-transcript-json)
+    require_session_args "$@"
+    apple_transcript_json "$1" "$2"
+    ;;
+  apple-transcript-text)
+    require_session_args "$@"
+    apple_transcript_text "$1" "$2"
+    ;;
+  transcript-url)
+    require_session_args "$@"
+    transcript_url "$1" "$2"
+    ;;
+  transcript-json)
+    require_session_args "$@"
+    resolved_transcript_json "$1" "$2"
+    ;;
+  transcript | transcript-text)
+    require_session_args "$@"
+    resolved_transcript_text "$1" "$2"
+    ;;
+  -h | --help | help | '')
+    usage
+    ;;
+  *)
+    echo "Unknown command: ${cmd}" >&2
+    usage >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Adds a WWDC skill copied from the wwdc.ai workspace into this skills repository.

The skill documents when to use WWDC.ai summaries and transcripts, includes endpoint reference notes, and bundles a helper script for fetching session indexes, markdown pages, HTML, and transcript data.

Validation: ran `bash -n skills/wwdc/scripts/wwdc.sh` and reviewed the branch diff against `origin/main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive skill docs and an optional local fetch script; no changes to auth, app runtime, or existing sync config in this diff.
> 
> **Overview**
> Adds a new **`wwdc`** agent skill so agents can answer WWDC session questions using **WWDC.ai** as the primary source (summaries first, plain transcripts when summaries are thin).
> 
> **`SKILL.md`** defines when to use the skill and points to **`scripts/wwdc.sh`** for `llms`, session markdown (`summary`), and timestamp-free `transcript` output. **`references/docs.md`** documents WWDC.ai URLs (`llms.txt`, year/session `.md` pages) and the full script command surface, including Apple transcript JSON resolution and env overrides (`WWDC_AI_BASE_URL`, `WWDC_APPLE_TRANSCRIPT_MANIFEST_URLS`).
> 
> **`wwdc.sh`** is a ~266-line bash helper that fetches indexes and session content via `curl`, resolves transcript URLs from session markdown, WWDC.ai static JSON, or Apple’s manifest, and uses **Node** to parse JSON into plain transcript text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca436dafbc58c30f4c854d6caa40a95130ca2c76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->