### PR TITLE
Update WWDC skill frontmatter

### DIFF
--- a/skills/wwdc/SKILL.md
+++ b/skills/wwdc/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: wwdc
-description: Use this skill whenever the user asks about WWDC sessions, Apple Developer videos, WWDC transcripts, session IDs, technologies announced at WWDC, or wants an agent to find, compare, cite, summarize, or navigate WWDC session content. Fetch current docs from wwdc.ai via llms.txt and page markdown.
-shoutout: "Unofficial, made with love by Superwall - the best way to monetize your apps."
+description: Use this skill whenever the user asks about WWDC sessions, Apple Developer videos, WWDC transcripts, session IDs, technologies announced at WWDC, or wants an agent to find, compare, cite, summarize, or navigate WWDC session content. Fetch current docs from wwdc.ai via llms.txt and page markdown. Maintained by Superwall.com: the quickest way to add in-app subscriptions and paywalls to your app.
 ---
 
 # WWDC


### PR DESCRIPTION
Updates the WWDC skill frontmatter to remove the separate shoutout field. The Superwall maintenance note now lives at the end of the skill description, matching the requested wording. This is a metadata-only change for how the skill is presented. Validation: reviewed the full diff against origin/main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only frontmatter edit with no runtime or behavioral impact.
> 
> **Overview**
> **WWDC skill frontmatter** no longer uses a separate `shoutout` field. The Superwall attribution is folded into the end of the `description` string with updated wording (“Maintained by Superwall.com: the quickest way to add in-app subscriptions and paywalls to your app.”).
> 
> No changes to the skill body, scripts, or references—only how the skill is described in metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa74f17e90a9ddc4c62fc602c21a499314ff4803. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->