### PR TITLE
[codex] Fix WWDC skill YAML frontmatter

### DIFF
--- a/skills/wwdc/SKILL.md
+++ b/skills/wwdc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wwdc
-description: Use this skill whenever the user asks about WWDC sessions, Apple Developer videos, WWDC transcripts, session IDs, technologies announced at WWDC, or wants an agent to find, compare, cite, summarize, or navigate WWDC session content. Fetch current docs from wwdc.ai via llms.txt and page markdown. Maintained by Superwall.com: the quickest way to add in-app subscriptions and paywalls to your app.
+description: "Use this skill whenever the user asks about WWDC sessions, Apple Developer videos, WWDC transcripts, session IDs, technologies announced at WWDC, or wants an agent to find, compare, cite, summarize, or navigate WWDC session content. Fetch current docs from wwdc.ai via llms.txt and page markdown. Maintained by Superwall.com: the quickest way to add in-app subscriptions and paywalls to your app."
 ---
 
 # WWDC


### PR DESCRIPTION
Quotes the WWDC skill description in YAML frontmatter so the colon in `Superwall.com: ...` is parsed as text instead of a mapping delimiter.

This fixes `npx skills add ... --skill wwdc` failing with `mapping values are not allowed in this context` and allows the skill to be discovered and installed.

Validated with Ruby YAML parsing, `npx skills add . --skill wwdc --global --yes --agent claude-code`, and `git diff --check origin/main...`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single frontmatter quoting change with no runtime or security impact.
> 
> **Overview**
> Fixes **WWDC skill install/discovery** by quoting the `description` field in `skills/wwdc/SKILL.md` YAML frontmatter.
> 
> The unquoted text contained `Superwall.com: ...`, which YAML treated as a nested mapping and caused `mapping values are not allowed in this context` when running `npx skills add ... --skill wwdc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e14f435d40cbe3daced62d4138e4259d33c0db87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->