### PR TITLE
Update README structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,24 +16,31 @@ Official [Agent Skills](https://agentskills.io/home) for integrating Superwall S
 
 We recommend using [skills.sh](https://skills.sh) CLI to install the skills.
 
-
 Install all skills:
 
 ```bash
 npx skills add superwall/skills
 ```
 
-Install the general skill:
+Install the main skill:
 
 ```bash
 npx skills add superwall/skills --skill superwall
 ```
 
-## Setup
+## Skills
+
+- [`superwall`](#superwall) — REST API access, ClickHouse analytics, documentation lookup, SDK integration triage, dashboard links, and SDK source cloning.
+- [`superwall-editor`](#superwall-editor) — live Superwall paywall, onboarding, and web2app editing from the CLI.
+- [`wwdc`](#wwdc) — WWDC session lookup, comparison, citation, summarization, and transcript navigation using [wwdc.ai](https://wwdc.ai/).
+
+## superwall
+
+Use the `superwall` skill when you need to manage Superwall projects, paywalls, campaigns, products, entitlements, webhooks, assets, or dashboard configuration. It also covers Superwall documentation lookup, SDK integration triage, SDK source inspection, and ClickHouse-backed product analytics.
 
 ### API Key
 
-The `superwall` skill uses the Superwall REST API to manage projects, paywalls, campaigns, products, and more. To enable API access, add your **org-scoped API key** to the environment:
+To enable API access, add your **org-scoped API key** to the environment:
 
 ```bash
 export SUPERWALL_API_KEY=<your-org-api-key>
@@ -69,3 +76,37 @@ To fully use the `superwall` skill, your API key needs the following scopes:
 | `assets:write` | Upload and manage assets |
 
 > If you only need read-only access, the `:read` scopes are sufficient for browsing your Superwall data.
+
+## superwall-editor
+
+Use the `superwall-editor` skill when you want an agent to build, modify, or review a live Superwall paywall, onboarding flow, or web2app flow.
+
+The editor skill attaches to a running browser editor session, discovers the tools currently exposed by that browser, and invokes those tools from the CLI. Prefer the API launch flow when you have `SUPERWALL_API_KEY`, an application id, and a paywall id:
+
+```bash
+scripts/sw-editor.sh expose --application-id <id> --paywall-id <id> --agent-name <agent> --open --wait
+scripts/sw-editor.sh tools
+scripts/sw-editor.sh call <tool-name> --args '<json>'
+```
+
+If the API launch flow is not available, use the pairing code shown in the editor:
+
+```bash
+scripts/sw-editor.sh attach <pairing-code>
+scripts/sw-editor.sh tools
+scripts/sw-editor.sh call <tool-name> --args '<json>'
+```
+
+See the skill references for the full CLI lifecycle, native `sw-*` elements, paywall editing workflow, and design standards.
+
+## wwdc
+
+Use the `wwdc` skill when you need current Apple Developer session context while working on Superwall integrations. It can find, compare, cite, and summarize WWDC session content, including transcripts and session IDs, using [wwdc.ai](https://wwdc.ai/).
+
+The bundled helper can list available WWDC.ai markdown pages and fetch session summaries or transcripts:
+
+```bash
+scripts/wwdc.sh llms
+scripts/wwdc.sh summary 2026 389
+scripts/wwdc.sh transcript 2026 309
+```


### PR DESCRIPTION
Restructures the README around all shipped skills instead of only the main Superwall skill.

Adds a skills table of contents and dedicated sections for `superwall`, `superwall-editor`, and `wwdc`, including a link to wwdc.ai and helper command examples.

Moves the existing Superwall API key and scope guidance under the `superwall` section so setup information stays attached to the relevant skill.

Validation: reviewed `git diff origin/main...`; no tests were run because this is a docs-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime or configuration behavior changes.
> 
> **Overview**
> **Restructures the README** so it documents all shipped skills, not only the core `superwall` skill.
> 
> Replaces the old **Setup** section with a **Skills** overview (links to `superwall`, `superwall-editor`, and `wwdc`) and adds dedicated sections for each. The install blurb now says “main skill” instead of “general skill.”
> 
> **`superwall`** — API key and required-scopes tables stay the same but sit under this heading, with slightly tightened intro copy.
> 
> **`superwall-editor`** — New guidance on when to use the skill plus example `scripts/sw-editor.sh` flows (API `expose` vs pairing-code `attach`, then `tools` / `call`).
> 
> **`wwdc`** — New section linking [wwdc.ai](https://wwdc.ai/) and sample `scripts/wwdc.sh` commands for listings, summaries, and transcripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 129ba4dc94de4e03360a00249ae9e3efce0e27d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->